### PR TITLE
Add AUR link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ $ cd mantablockscreen
 ```
 3. Run `$ sudo make install`
 
+You can also install it via [AUR](https://aur.archlinux.org/packages/mantablockscreen/) if you are running Arch Linux
+
 ## Usage
 To create cached images run command below <br>
 `$ mantablockscreen -i PATH/TO/YOUR/IMAGE` <br>


### PR DESCRIPTION
As I created an AUR repo in order to install mantablockscreen on Arch Linux, maybe it could be interesting to put the link in the README ?