### PR TITLE
Keep installation fully within /usr/local by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@ ifeq ($(PREFIX),)
 	PREFIX := /usr/local
 endif
 
+pkgdatadir = $(PREFIX)/share/mantabassets
 .PHONY: install
 install:
+	sed "s|@pkgdatadir[@]|$(pkgdatadir)|g" mantablockscreen.in > mantablockscreen
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -d $(DESTDIR)$(PREFIX)/share/mantabassets
 	install -m 755 mantablockscreen $(DESTDIR)$(PREFIX)/bin/mantablockscreen

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,13 @@ ifeq ($(PREFIX),)
 	PREFIX := /usr/local
 endif
 
-pkgdatadir = $(PREFIX)/share/mantabassets
 .PHONY: install
 install:
-	sed "s|@pkgdatadir[@]|$(pkgdatadir)|g" mantablockscreen.in > mantablockscreen
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -d $(DESTDIR)$(PREFIX)/share/mantabassets
-	install -m 755 mantablockscreen $(DESTDIR)$(PREFIX)/bin/mantablockscreen
-	install -m 755 mantabassets/* $(DESTDIR)$(PREFIX)/share/mantabassets/
+	sed 's|@pkgdatadir[@]|$(PREFIX)/share/mantabassets|g' mantablockscreen.in > mantablockscreen
+	install -D mantablockscreen '$(DESTDIR)$(PREFIX)/bin/mantablockscreen'
+	install -D mantabassets/* -t '$(DESTDIR)$(PREFIX)/share/mantabassets/'
 
 .PHONY: uninstall
 uninstall:
-	test -e $(DESTDIR)$(PREFIX)/bin/mantablockscreen && rm $(DESTDIR)$(PREFIX)/bin/mantablockscreen
-	test -d $(DESTDIR)$(PREFIX)/share/mantabassets && rm -rf $(DESTDIR)$(PREFIX)/share/mantabassets || exit 0
+	rm -f '$(DESTDIR)$(PREFIX)/bin/mantablockscreen'
+	rm -rf '$(DESTDIR)$(PREFIX)/share/mantabassets'

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 ifeq ($(PREFIX),)
-	PREFIX := /usr
+	PREFIX := /usr/local
 endif
 
 .PHONY: install
 install:
-	install -d $(DESTDIR)$(PREFIX)/local/bin
+	install -d $(DESTDIR)$(PREFIX)/bin
 	install -d $(DESTDIR)$(PREFIX)/share/mantabassets
-	install -m 755 mantablockscreen $(DESTDIR)$(PREFIX)/local/bin/mantablockscreen
+	install -m 755 mantablockscreen $(DESTDIR)$(PREFIX)/bin/mantablockscreen
 	install -m 755 mantabassets/* $(DESTDIR)$(PREFIX)/share/mantabassets/
 
 .PHONY: uninstall
 uninstall:
-	test -e $(DESTDIR)$(PREFIX)/local/bin/mantablockscreen && rm $(DESTDIR)$(PREFIX)/local/bin/mantablockscreen
+	test -e $(DESTDIR)$(PREFIX)/bin/mantablockscreen && rm $(DESTDIR)$(PREFIX)/bin/mantablockscreen
 	test -d $(DESTDIR)$(PREFIX)/share/mantabassets && rm -rf $(DESTDIR)$(PREFIX)/share/mantabassets || exit 0

--- a/mantablockscreen
+++ b/mantablockscreen
@@ -24,7 +24,7 @@ verif_color=fefefe66
 cropuser() {
 	ava_home=$HOME/.face
 	ava_var=/var/lib/AccountsService/icons/$USER
-	userpic=/usr/share/mantabassets/userpic.png
+	userpic=/usr/local/share/mantabassets/userpic.png
 	if [[ -e $ava_home ]]; then
 		userpic=$ava_home
 	elif [[ -e $ava_var ]]; then
@@ -139,7 +139,7 @@ circleclock() {
 }
 
 show_help(){
-	cat <<-EOF                                 
+	cat <<-EOF
 	Usage :
 	 mantablockscreen [OPTION]
 
@@ -152,8 +152,8 @@ show_help(){
 	EOF
 }
 
-case $1 in 
-	-i|--image) 
+case $1 in
+	-i|--image)
 		genbg $2 ;;
 	-h|--help)
 		show_help ;;

--- a/mantablockscreen.in
+++ b/mantablockscreen.in
@@ -24,7 +24,7 @@ verif_color=fefefe66
 cropuser() {
 	ava_home=$HOME/.face
 	ava_var=/var/lib/AccountsService/icons/$USER
-	userpic=/usr/local/share/mantabassets/userpic.png
+	userpic=@pkgdatadir@/userpic.png
 	if [[ -e $ava_home ]]; then
 		userpic=$ava_home
 	elif [[ -e $ava_var ]]; then


### PR DESCRIPTION
The current Makefile installs the script to `$PREFIX/local/bin` rather than `$PREFIX/bin` while installing assets to `$PREFIX/share` (not `$PREFIX/local/share`), which prevents distro package managers from avoiding installation in `/usr/local`. At least on Arch Linux, the package manager must not install to `/usr/local` since it is reserved for manually installed packages.

The first commit of this pull request will install both the script and assets within `/usr/local` rather than a mixture of `/usr` and `usr/local` to enable package managers to abide by the File System Hierarchy. It is the only necessary commit.

The second commit removes the hard-coded `userpic` path within the script which assumes assets are installed at `/usr/share`, given that the `PREFIX` defaults to `/usr/local` and so assets by default install to `/usr/local/share` instead. It enables the script to work even if installed elsewhere, for example in `/usr/local` as is default.

The third commit cleans up the Makefile.